### PR TITLE
Save edited tasks locally

### DIFF
--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { RiCloseFill, RiStarSFill, RiStarSLine } from "react-icons/ri";
 import styled from "styled-components";
-
+import useOutsideClick from "../Hooks/useOutsideClick";
 import moment from "moment";
 
 const Checkbox = styled.input`
@@ -79,39 +79,26 @@ const Task = ({
     }
   }, [isEdit]);
 
-  // const editKeyDown = (e) => {
-  //   if (editRef.current && editRef.current.contains(e.target)) {
-  //     // inside click
-  //     console.log("init");
-  //     if (e.key === "Enter") {
-  //       setEdit(edit);
-  //       setIsEdit(false);
-  //       console.log("inside");
-  //     }
-  //     console.log("outside");
-  //   }
-  //   console.log(e);
-  //   // outside click
-  //   setEdit(false);
 
-  //   console.log(e);
-  //   if (e.key === "Enter") {
-  //     setEdit(edit);
-  //     setIsEdit(false);
-  //   }
-  // };
-
-  const editKeyDown = (e) => {
+  const editKeyDown = (e) => { // stops edit when enter is hit in edit input.
     if (e.key === "Enter") {
-      if (edit === "" || /^\s*$/.test(edit)) {
+      if (edit === "" || /^\s*$/.test(edit)) { // check input
         console.log("Invalid edit");
         return;
       }
-      console.log("setEdit triggered");
-      setEdit(edit);
-      setIsEdit(false);
+      setEdit(edit); //change value of edit,
+      setIsEdit(false); // set edit attribute to false,
+      editTask(id, edit); // update the task globally.
     }
   };
+
+  useOutsideClick(editRef, () => { // stops edit when clicked outside of edit input.
+    if (edit === "") { // if left blank, delete task
+      removeTask(id);
+    } else { // update task
+      editTask(id, edit)
+    }  
+  });
 
   var untilScheduleDate = moment(scheduleDate).fromNow();
   var untilDueDate = moment(dueDate).fromNow();

--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -79,12 +79,8 @@ const Task = ({
     }
   }, [isEdit]);
 
-<<<<<<< HEAD
 
   const editKeyDown = (e) => { // stops edit when enter is hit in edit input.
-=======
-  const editKeyDown = (e) => {
->>>>>>> c0c77428835991355624905cf993d35e159cbbe3
     if (e.key === "Enter") {
       if (edit === "" || /^\s*$/.test(edit)) { // check input
         console.log("Invalid edit");

--- a/src/screens/TaskScreen.js
+++ b/src/screens/TaskScreen.js
@@ -36,8 +36,7 @@ import moment from "moment";
 // var dd = String(todayDate.getDate()).padStart(2, "0");
 // var mm = String(todayDate.getMonth() + 1).padStart(2, "0"); //January is 0!
 // var yyyy = todayDate.getFullYear();
-var todayDate = moment().format("YYYY-MM-D");
-
+var todayDate = moment().format("YYYY-MM-DD");
 console.log(todayDate);
 
 const TaskScreen = ({
@@ -71,14 +70,14 @@ const TaskScreen = ({
     setTasks(newTasks);
   };
 
-  const editTask = (taskId, newTitle) => {
-    // if (!newTitle.title || /^\s*$/.test(newTitle.text)) {
-    //   return;
-    // }
-
-    setTasks((prev) =>
-      prev.map((task) => (task.id === taskId ? newTitle : task))
-    );
+  const editTask = (id, taskTitle) => {
+    let newTasks = tasks.map((task) => { // map through tasks
+      if (task.key === id) { // find key
+        task.title = taskTitle; // update title
+      }
+      return task;
+    });
+    setTasks(newTasks); // update Tasks
   };
 
   const completeTask = (key) => {


### PR DESCRIPTION
Can now edit and save tasks after enter key is pressed or clicked outside. If clicked outside when the task is empty, the task is deleted.